### PR TITLE
Size of intercept_ in LDA should be n_classes

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -186,7 +186,7 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
     coef_ : array, shape (n_features,) or (n_classes, n_features)
         Weight vector(s).
 
-    intercept_ : array, shape (n_features,)
+    intercept_ : array, shape (n_classes,)
         Intercept term.
 
     covariance_ : array-like, shape (n_features, n_features)


### PR DESCRIPTION
In a mutliclass LDA classification the size of

Weights (coeff) are `n_classes x n_features`
Intercept is `n_classes`
In documentation for intercept it is given as shape (n_features,) which is wrong.


#14952

Corrected the documentation  

